### PR TITLE
Check to see if Math.ln exists before using it.

### DIFF
--- a/Source/zizhujy.com.IntervalArithmetic.js
+++ b/Source/zizhujy.com.IntervalArithmetic.js
@@ -367,9 +367,15 @@
         },
 
         ln: function (interval) {
-            var l = Math.ln(interval.val[0]);
-            var t = Math.ln(interval.val[1]);
-
+            if (Math.ln !== undefined){
+                var l = Math.ln(interval.val[0]);
+                var t = Math.ln(interval.val[1]);
+            } else {
+                // On latest Firefox/Ubuntu Math.ln is undefined, as Math.log() takes the natural log.
+                var l = Math.log(interval.val[0]);
+                var t = Math.log(interval.val[1]);
+            }
+            
             var def = interval.def;
             if (isNaN(l) && isNaN(t)) def = [false, false];
             else if (isNaN(l) || isNaN(t)) def = [false, interval.def[1]];


### PR DESCRIPTION
On my system (and I assume many others), Math.ln() does not exist.
By default, Math.log() takes the natural log of a number, so I have added a check to see if Math.ln() exists, and if it does not, to use Math.log() instead.